### PR TITLE
Fix provisioning failure (NO_JIRA)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 chocolatey_mirror_username: "{{ ansible_deployment_artifactory_user }}"
 chocolatey_mirror_password: "{{ ansible_deployment_artifactory_key }}"
-chocolatey_sources:
+chocolatey_sources: []


### PR DESCRIPTION
```TASK [ccdc.package_manager_configuration : Add sources to choco] ***************
task path: /Users/piesche/Development/_vagrant-boxes/vagrant-test-windows/roles/ccdc.package_manager_configuration/tasks/Windows.yml:55
[ERROR]: The `loop` value must resolve to a 'list', not 'NoneType'.
Origin: /Users/piesche/Development/_vagrant-boxes/vagrant-test-windows/roles/ccdc.package_manager_configuration/tasks/Windows.yml:63:9

61     source_password: "{{ chocolatey_mirror_password }}"
62   become: true
63   loop: "{{ chocolatey_sources }}"
           ^ column 9

Provide a list of items/templates, or a template resolving to a list.

fatal: [win10]: FAILED! => {
    "changed": false,
    "msg": "The `loop` value must resolve to a 'list', not 'NoneType'."
}
```